### PR TITLE
Add logout option and improve login theme

### DIFF
--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -11,21 +11,30 @@ class LoginScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
     return Scaffold(
+      backgroundColor: colorScheme.background,
       body: Center(
         child: Padding(
           padding: const EdgeInsets.all(24.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              const Text(
+              Text(
                 'Learning English AI',
-                style: TextStyle(fontSize: 28, fontWeight: FontWeight.bold),
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
               ),
               const SizedBox(height: 40),
-              const Text(
+              Text(
                 'Inicia sesión para continuar',
-                style: TextStyle(fontSize: 18),
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: Colors.white70,
+                ),
               ),
               const SizedBox(height: 40),
               if (errorMessage != null)

--- a/lib/features/chat_ai/presentation/screens/home_screen.dart
+++ b/lib/features/chat_ai/presentation/screens/home_screen.dart
@@ -37,6 +37,14 @@ class HomeScreen extends StatelessWidget {
               child: Icon(Icons.person, color: Colors.white),
             ),
           ),
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () {
+              context
+                  .read<AuthBloc>()
+                  .add(const AuthLogoutRequested());
+            },
+          ),
         ],
       ),
       body: Padding(


### PR DESCRIPTION
## Summary
- style login screen using app theme
- add logout button on home screen

## Testing
- `dart format --set-exit-if-changed lib/features/auth/presentation/screens/login_screen.dart lib/features/chat_ai/presentation/screens/home_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d135951748331946ad34a36d39e19