### PR TITLE
feat: pronounce english words with mixed language TTS

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,6 +40,7 @@ dependencies:
   auto_route: ^7.8.4
   flutter_svg: ^2.0.9
   lottie: ^2.7.0
+  english_words: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add english_words package for basic language detection
- implement language-aware speak() that switches between Venezuelan Spanish and English voices using FlutterTts
- include optional SSML helper and default Spanish configuration

## Testing
- `flutter pub get` *(command not found: flutter)*
- `dart format lib/features/chat_ai/presentation/screens/ai_call_screen.dart pubspec.yaml` *(command not found: dart)*
- `flutter analyze` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68911806150483319a3ca2898bff6408