### PR TITLE
feat: add google tts to ai call

### DIFF
--- a/lib/features/chat_ai/data/services/google_tts_service.dart
+++ b/lib/features/chat_ai/data/services/google_tts_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:http/http.dart' as http;
+
+/// Service that wraps Google Cloud Text-to-Speech API.
+/// It requires the environment variable `GOOGLE_TTS_API_KEY` to be set.
+class GoogleTtsService {
+  final String _apiKey = dotenv.env['GOOGLE_TTS_API_KEY'] ?? '';
+
+  /// Synthesizes [text] into speech using the provided [voice] and [languageCode].
+  /// Returns the audio content as raw bytes in MP3 format.
+  Future<Uint8List> synthesize({
+    required String text,
+    required String voice,
+    required String languageCode,
+  }) async {
+    final uri = Uri.parse(
+        'https://texttospeech.googleapis.com/v1/text:synthesize?key=$_apiKey');
+
+    final response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json; charset=utf-8'},
+      body: jsonEncode({
+        'input': {'text': text},
+        'voice': {
+          'languageCode': languageCode,
+          'name': voice,
+        },
+        'audioConfig': {'audioEncoding': 'MP3'},
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('TTS request failed: ${response.body}');
+    }
+
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    final audioContent = data['audioContent'] as String;
+    return base64.decode(audioContent);
+  }
+}


### PR DESCRIPTION
## Summary
- use Google Cloud Text-to-Speech for AI call responses
- play synthesized audio with audioplayers

## Testing
- `dart format lib/features/chat_ai/presentation/screens/ai_call_screen.dart lib/features/chat_ai/data/services/google_tts_service.dart` *(fails: bash: command not found: dart)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891691f3d2083318ddc7d6755fb0386