### PR TITLE
Persist session ID for chat queries

### DIFF
--- a/lib/features/chat_ai/data/services/chat_query_service.dart
+++ b/lib/features/chat_ai/data/services/chat_query_service.dart
@@ -3,10 +3,20 @@ import 'package:http/http.dart' as http;
 
 class ChatQueryService {
   final http.Client _client;
+  String? _sessionId;
 
   ChatQueryService({http.Client? client}) : _client = client ?? http.Client();
 
   Future<QueryResponse> query(String message) async {
+    final Map<String, dynamic> body = {
+      'message': message,
+      'bot_id': '6886d2b8cbc07515ccb33a2a',
+    };
+
+    if (_sessionId != null && _sessionId!.isNotEmpty) {
+      body['session_id'] = _sessionId;
+    }
+
     final response = await _client.post(
       Uri.parse('https://dapi.pulbot.store/api/v1/rag/query'),
       headers: {
@@ -14,10 +24,7 @@ class ChatQueryService {
         'Accept': 'application/json',
         'X-API-Key': '0GRkN3gPg81DYsLhxeIzar1t',
       },
-      body: jsonEncode({
-        'message': message,
-        'bot_id': '6886d2b8cbc07515ccb33a2a',
-      }),
+      body: jsonEncode(body),
     );
 
     if (response.statusCode != 200) {
@@ -27,6 +34,9 @@ class ChatQueryService {
     final Map<String, dynamic> data = jsonDecode(response.body);
     final answer = data['data']?['answer'] as String? ?? '';
     final sessionId = data['data']?['session_id'] as String? ?? '';
+    if (sessionId.isNotEmpty) {
+      _sessionId = sessionId;
+    }
     return QueryResponse(answer: answer, sessionId: sessionId);
   }
 }


### PR DESCRIPTION
## Summary
- cache session ID returned from chat query API
- include stored session ID on subsequent requests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689627201dc48331bd7d90916d11f44e