### PR TITLE
feat: route chat services

### DIFF
--- a/lib/features/chat_ai/data/services/chat_stream_service.dart
+++ b/lib/features/chat_ai/data/services/chat_stream_service.dart
@@ -1,74 +1,52 @@
 import 'dart:convert';
-import 'package:http/http.dart' as http;
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 class ChatStreamService {
-  final http.Client _client;
-  String? sessionId; // Variable para almacenar el session_id
+  WebSocketChannel? _channel;
+  String? _sessionId;
 
-  ChatStreamService({http.Client? client}) : _client = client ?? http.Client();
-
-  Stream<String> queryStream(String message) async* {
-    final request = http.Request(
-      'POST',
-      Uri.parse('https://dapi.pulbot.store/api/v1/rag/query-stream'),
-    )
-      ..headers.addAll({
+  void _ensureConnected() {
+    _channel ??= WebSocketChannel.connect(
+      Uri.parse('wss://dapi.pulbot.store/api/v1/rag/query-stream'),
+      headers: {
+        'X-API-Key': '0GRkN3gPg81DYsLhxeIzar1t',
         'Content-Type': 'application/json',
         'Accept': 'application/json',
-        'X-API-Key': '0GRkN3gPg81DYsLhxeIzar1t',
-      })
-      ..body = jsonEncode({
-        'message': message,
-        'bot_id': '68961f300f36ac73e8dff085',
-      });
-
-    try {
-      final response = await _client.send(request);
-      if (response.statusCode != 200) {
-        throw http.ClientException('An error occurred, please try again later.');
-      }
-
-      // Captura el session_id de los headers
-      final sessionIdFromResponse = response.headers['x-session-id'];
-      if (sessionIdFromResponse != null) {
-        sessionId = sessionIdFromResponse; // Almacena el session_id
-      }
-
-      await for (final chunk in response.stream.transform(utf8.decoder)) {
-        yield chunk;
-      }
-    } catch (e) {
-      throw Exception('Stream error: $e');
-    }
+      },
+    );
   }
 
-  // Método para enviar solicitudes adicionales con el session_id
-  Future<http.Response> sendFollowUpRequest(String message) async {
-    final request = http.Request(
-      'POST',
-      Uri.parse('https://dapi.pulbot.store/api/v1/rag/query-stream'),
-    )
-      ..headers.addAll({
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'X-API-Key': '0GRkN3gPg81DYsLhxeIzar1t',
-        'X-Session-ID': sessionId ?? '', // Incluye el session_id en la solicitud
-      })
-      ..body = jsonEncode({
-        'message': message,
-        'bot_id': '68961f300f36ac73e8dff085',
-        'session_id': sessionId ?? '', 
-      });
-
-    try {
-      final response = await _client.send(request);
-      if (response.statusCode != 200) {
-        throw http.ClientException('An error occurred, please try again later.');
-      }
-
-      return await http.Response.fromStream(response);
-    } catch (e) {
-      throw Exception('Error sending follow-up request: $e');
+  Stream<String> sendMessage(String message) {
+    _ensureConnected();
+    final payload = {
+      'message': message,
+      'bot_id': '68961f300f36ac73e8dff085',
+    };
+    if (_sessionId != null && _sessionId!.isNotEmpty) {
+      payload['session_id'] = _sessionId;
     }
+    _channel!.sink.add(jsonEncode(payload));
+
+    return _channel!.stream.map((event) {
+      try {
+        final data = jsonDecode(event);
+        final sessionIdFromResponse =
+            data['data']?['session_id'] as String? ?? data['session_id'] as String?;
+        if (sessionIdFromResponse != null && sessionIdFromResponse.isNotEmpty) {
+          _sessionId = sessionIdFromResponse;
+        }
+        final answer = data['data']?['answer'] as String? ??
+            data['answer'] as String? ??
+            event.toString();
+        return answer;
+      } catch (_) {
+        return event.toString();
+      }
+    });
+  }
+
+  void dispose() {
+    _channel?.sink.close();
+    _channel = null;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1187,7 +1187,7 @@ packages:
     source: hosted
     version: "1.0.1"
   web_socket_channel:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   flutter_svg: ^2.0.9
   lottie: ^2.7.0
   english_words: ^4.0.0
+  web_socket_channel: ^3.0.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- swap chat screen to use query service for responses
- move AI call to socket-based stream service
- wire chat stream service through web sockets

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689655af2e388331a414336fdcee968b